### PR TITLE
HOTFIX draft posts don't show in dashboard

### DIFF
--- a/wp-content/plugins/hurumap/index.php
+++ b/wp-content/plugins/hurumap/index.php
@@ -95,7 +95,8 @@ class HURUmap {
             $results = get_posts([
                 'post_type' => 'hurumap-section',
                 'numberposts' => -1,
-                'suppress_filters' => 0
+                'suppress_filters' => 0,
+                'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash') 
               ]);
             $sections = array();
             foreach ($results as $result) {
@@ -108,7 +109,13 @@ class HURUmap {
              * Get post then use get_posts to get the post with language filters
              */
             $_post = get_post();
-            $post = get_posts(['numberposts' => 1, 'post_type' => $_post->post_type, 'post__in' => [$_post->ID], 'suppress_filters' => 0])[0];
+            $post = get_posts([
+                'numberposts' => 1, 
+                'post_type' => $_post->post_type, 
+                'post__in' => [$_post->ID], 
+                'suppress_filters' => 0,
+                'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash') 
+            ])[0];
 
             wp_localize_script('hurumap-definitions-admin-script-index.js', 'initial', 
                 array(
@@ -149,7 +156,8 @@ class HURUmap {
             $results = get_posts([
                 'post_type' => 'hurumap-visual',
                 'numberposts' => -1,
-                'suppress_filters' => 0
+                'suppress_filters' => 0,
+                'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash') 
               ]);
             $charts = array();
             foreach ($results as $result) {
@@ -158,7 +166,8 @@ class HURUmap {
             $results = get_posts([
                 'post_type' => 'hurumap-section',
                 'numberposts' => -1, 
-                'suppress_filters' => 0
+                'suppress_filters' => 0,
+                'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash') 
               ]);
             $sections = array();
             foreach ($results as $result) {
@@ -170,7 +179,8 @@ class HURUmap {
                 'post_type' => $_section->post_type,
                 'post__in' => [$_section->ID],
                 'numberposts' => 1,
-                'suppress_filters' => 0
+                'suppress_filters' => 0,
+                'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash') 
               ])[0];
 
             // Provide index js with initial data
@@ -247,12 +257,24 @@ class HURUmap {
         switch ( $column ) {
             case 'visual_type' :
                 $_post = get_post($post_id);
-                $post = get_posts(['numberposts' => 1, 'post_type' => $_post->post_type, 'post__in' => [$_post->ID], 'suppress_filters' => 0])[0];
+                $post = get_posts([
+                    'numberposts' => 1,
+                    'post_type' => $_post->post_type,
+                    'post__in' => [$_post->ID],
+                    'suppress_filters' => 0,
+                    'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash')
+                ])[0];
                 echo $post->post_excerpt;
                 break;
             case 'in_topics' : {
                 $_post = get_post($post_id);
-                $post = get_posts(['numberposts' => 1, 'post_type' => $_post->post_type, 'post__in' => [$_post->ID], 'suppress_filters' => 0])[0];
+                $post = get_posts([
+                    'numberposts' => 1,
+                    'post_type' => $_post->post_type,
+                    'post__in' => [$_post->ID],
+                    'suppress_filters' => 0,
+                    'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash')
+                ])[0];
                 $definition = json_decode($post->post_content, true);
                 if (is_array($definition['inTopics'])) {
                     $in_topics = $definition['inTopics'];


### PR DESCRIPTION
## Description

When a post gets saved as draft of trash etc `get_posts` should grab it for preview. 
We use `get_posts` because multilang filter works with `get_posts`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Desktop Screenshots

Fix:
<img width="1728" alt="Screen Shot 2020-04-01 at 9 18 19 AM" src="https://user-images.githubusercontent.com/4308339/78133848-c1946400-73f9-11ea-8861-0891088fe6b9.png">
Problem:
<img width="1732" alt="Screen Shot 2020-04-01 at 8 50 07 AM" src="https://user-images.githubusercontent.com/4308339/78133851-c22cfa80-73f9-11ea-8e94-fb85a380d4e3.png">

Problem:
<img width="1762" alt="Screen Shot 2020-04-01 at 8 50 26 AM" src="https://user-images.githubusercontent.com/4308339/78134054-1637df00-73fa-11ea-974e-e9a50705a88f.png">
Fix:
<img width="1756" alt="Screen Shot 2020-04-01 at 9 18 09 AM" src="https://user-images.githubusercontent.com/4308339/78134066-189a3900-73fa-11ea-8e61-10f1e3545f31.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
