### PR TITLE
Add Featured Documents Custom Field

### DIFF
--- a/wp-content/themes/hurumap/acf-json/group_5f32414d4c0ad.json
+++ b/wp-content/themes/hurumap/acf-json/group_5f32414d4c0ad.json
@@ -1,118 +1,118 @@
 {
-        "key": "group_5f32414d4c0ad",
-        "title": "Documents",
-        "fields": [
-            {
-                "key": "field_5f325f78505fd",
-                "label": "Featured Documents",
-                "name": "featured_documents",
-                "type": "repeater",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "collapsed": "field_5f324186d379d",
-                "min": 0,
-                "max": 0,
-                "layout": "block",
-                "button_label": "Add Document",
-                "sub_fields": [
-                    {
-                        "key": "field_5f324186d379d",
-                        "label": "Title",
-                        "name": "title",
-                        "type": "text",
-                        "instructions": "",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "default_value": "",
-                        "placeholder": "",
-                        "prepend": "",
-                        "append": "",
-                        "maxlength": ""
-                    },
-                    {
-                        "key": "field_5f32466ed379e",
-                        "label": "Description",
-                        "name": "description",
-                        "type": "text",
-                        "instructions": "",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "default_value": "",
-                        "placeholder": "",
-                        "prepend": "",
-                        "append": "",
-                        "maxlength": ""
-                    },
-                    {
-                        "key": "field_5f324684d379f",
-                        "label": "Source link",
-                        "name": "link",
-                        "type": "url",
-                        "instructions": "",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "default_value": "",
-                        "placeholder": ""
-                    },
-                    {
-                        "key": "field_5f32498ed37a0",
-                        "label": "Source file",
-                        "name": "source_file",
-                        "type": "file",
-                        "instructions": "",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "return_format": "array",
-                        "library": "all",
-                        "min_size": "",
-                        "max_size": "",
-                        "mime_types": ""
-                    }
-                ]
-            }
-        ],
-        "location": [
-            [
+    "key": "group_5f32414d4c0ad",
+    "title": "Documents",
+    "fields": [
+        {
+            "key": "field_5f325f78505fd",
+            "label": "Featured Documents",
+            "name": "featured_documents",
+            "type": "repeater",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "collapsed": "field_5f324186d379d",
+            "min": 0,
+            "max": 0,
+            "layout": "block",
+            "button_label": "Add Document",
+            "sub_fields": [
                 {
-                    "param": "page",
-                    "operator": "==",
-                    "value": "research-documents"
+                    "key": "field_5f324186d379d",
+                    "label": "Title",
+                    "name": "title",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5f32466ed379e",
+                    "label": "Description",
+                    "name": "description",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5f324684d379f",
+                    "label": "Source link",
+                    "name": "link",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": ""
+                },
+                {
+                    "key": "field_5f32498ed37a0",
+                    "label": "Source file",
+                    "name": "source_file",
+                    "type": "file",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "return_format": "array",
+                    "library": "all",
+                    "min_size": "",
+                    "max_size": "",
+                    "mime_types": ""
                 }
             ]
-        ],
-        "menu_order": 0,
-        "position": "normal",
-        "style": "default",
-        "label_placement": "left",
-        "instruction_placement": "label",
-        "hide_on_screen": "",
-        "active": true,
-        "description": "",
-        "modified": 1597139300
-    }
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "page",
+                "operator": "==",
+                "value": "research-documents"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "left",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1597139300
+}

--- a/wp-content/themes/hurumap/acf-json/group_5f32414d4c0ad.json
+++ b/wp-content/themes/hurumap/acf-json/group_5f32414d4c0ad.json
@@ -61,8 +61,8 @@
                 },
                 {
                     "key": "field_5f324684d379f",
-                    "label": "Source link",
-                    "name": "link",
+                    "label": "Source",
+                    "name": "source",
                     "type": "url",
                     "instructions": "",
                     "required": 0,
@@ -77,8 +77,8 @@
                 },
                 {
                     "key": "field_5f32498ed37a0",
-                    "label": "Source file",
-                    "name": "source_file",
+                    "label": "Document",
+                    "name": "document",
                     "type": "file",
                     "instructions": "",
                     "required": 0,
@@ -114,5 +114,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1597139300
+    "modified": 1597150154
 }

--- a/wp-content/themes/hurumap/acf-json/group_5f32414d4c0ad.json
+++ b/wp-content/themes/hurumap/acf-json/group_5f32414d4c0ad.json
@@ -1,0 +1,118 @@
+{
+        "key": "group_5f32414d4c0ad",
+        "title": "Documents",
+        "fields": [
+            {
+                "key": "field_5f325f78505fd",
+                "label": "Featured Documents",
+                "name": "featured_documents",
+                "type": "repeater",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "collapsed": "field_5f324186d379d",
+                "min": 0,
+                "max": 0,
+                "layout": "block",
+                "button_label": "Add Document",
+                "sub_fields": [
+                    {
+                        "key": "field_5f324186d379d",
+                        "label": "Title",
+                        "name": "title",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5f32466ed379e",
+                        "label": "Description",
+                        "name": "description",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5f324684d379f",
+                        "label": "Source link",
+                        "name": "link",
+                        "type": "url",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": ""
+                    },
+                    {
+                        "key": "field_5f32498ed37a0",
+                        "label": "Source file",
+                        "name": "source_file",
+                        "type": "file",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "return_format": "array",
+                        "library": "all",
+                        "min_size": "",
+                        "max_size": "",
+                        "mime_types": ""
+                    }
+                ]
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "page",
+                    "operator": "==",
+                    "value": "research-documents"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "left",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": "",
+        "modified": 1597139300
+    }


### PR DESCRIPTION
## Description

- Add a repeater field for featured document on research document pages. This will replace the documents from source.AFRICA/openAFRICA

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Desktop Screenshots
![Screenshot from 2020-08-11 12-51-37](https://user-images.githubusercontent.com/7962097/89884236-ee3f6000-dbd1-11ea-9bb9-079d79621e8e.png)



## Mobile Screenshots



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
